### PR TITLE
Support node >= 4.0.0, npm >= 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "standard": "^10.0.3"
   },
   "engines": {
-    "node": ">= 8.9.1",
-    "npm": ">= 5.5.1"
+    "node": ">=4.0.0",
+    "npm": ">= 3.0.0"
   },
   "scripts": {
     "build": "rollup -c config.js",


### PR DESCRIPTION
Same as https://github.com/buxlabs/amd-to-es6/commit/711b68b85ae85ca7553b07e4c8111c9669b3f498

Handles npm version as well